### PR TITLE
fix broken links in some lists

### DIFF
--- a/crawl_lists/australia_top_525.csv
+++ b/crawl_lists/australia_top_525.csv
@@ -57,7 +57,7 @@ https://westpac.com.au
 https://uow.edu.au
 https://foxsports.com.au
 https://homeaffairs.gov.au
-REPLACE!!!
+https://runningcalendar.com.au
 https://crucial.com.au
 https://businessinsider.com.au
 https://hostingplatform.net.au

--- a/crawl_lists/general_top_525.csv
+++ b/crawl_lists/general_top_525.csv
@@ -407,7 +407,7 @@ https://patreon.com
 https://tandfonline.com
 https://amazon.co.jp
 https://hostgator.com.br
-https://sorbs.net
+https://www.sorbs.net
 https://ietf.org
 https://cornell.edu
 https://autodesk.com

--- a/crawl_lists/singapore_top_525.csv
+++ b/crawl_lists/singapore_top_525.csv
@@ -208,7 +208,7 @@ https://cyberway.com.sg
 https://smrt.com.sg
 https://sha.org.sg
 https://hostings.com.sg
-https://newport-residences-cdl.c
+https://newport-residences-cdl.com.sg
 https://fintechnews.sg
 https://caas.gov.sg
 https://duke-nus.edu.sg
@@ -320,7 +320,7 @@ https://ecitizen.gov.sg
 https://psb-academy.edu.sg
 https://srx.com.sg
 https://companies.sg
-https://interactivebrokers.com.s
+https://interactivebrokers.com.sg
 https://mytransport.sg
 https://hibrite.sg
 https://epson.com.sg
@@ -425,7 +425,7 @@ https://sas.edu.sg
 https://cathaycineplexes.com.sg
 https://intellisoft.com.sg
 https://smartnation.gov.sg
-https://philippine-embassy.org.s
+https://philippine-embassy.org.sg
 https://wrs.com.sg
 https://redeem.gov.sg
 https://newbalance.com.sg
@@ -442,7 +442,7 @@ https://keep.com.sg
 https://eezee.sg
 https://ieatishootipost.sg
 https://hrp.gov.sg
-https://healthprofessionals.gov.
+https://healthprofessionals.gov.sg
 https://livenation.sg
 https://shout.sg
 https://red-dot.sg

--- a/crawl_lists/southafrica_top_525.csv
+++ b/crawl_lists/southafrica_top_525.csv
@@ -178,7 +178,7 @@ https://adidas.co.za
 https://capetalk.co.za
 https://motorcyclespecs.co.za
 https://resbank.co.za
-https://sportsmanswarehouse.co.z
+https://sportsmanswarehouse.co.za
 https://snatcher.co.za
 https://pricecheck.co.za
 https://bidorbuy.co.za
@@ -450,7 +450,7 @@ https://worldonline.co.za
 https://blackbookmedia.co.za
 https://nashua.co.za
 https://compuscan.co.za
-https://barclaysafricagroup.co.z
+https://barclaysafricagroup.co.za
 https://trovit.co.za
 https://mobicred.co.za
 https://farmersweekly.co.za

--- a/crawl_lists/unitedstates_top_525.csv
+++ b/crawl_lists/unitedstates_top_525.csv
@@ -64,7 +64,7 @@ https://paypal.com
 https://unity3d.com
 https://cnn.com
 https://soundcloud.com
-https://salesforceliveagent.co
+https://salesforceliveagent.com
 https://example.com
 https://salesforce.com
 https://pubmatic.com


### PR DESCRIPTION
Was doing one last pass through the lists, and noticed that some links hadn't properly copied over. No major changes needed to be made. Apparently I had forgotten to replace one placeholder in the Australia list, but I've taken care of that. 