### PR TITLE
Issue 33 (Fixes to crawler error handling)

### DIFF
--- a/rest-api/index.js
+++ b/rest-api/index.js
@@ -13,9 +13,28 @@ if (args.length > 2 && args[2] == "debug") {
   debug = true;
 }
 
+// Given the name of an SQL table, will truncate (i.e. delete the contents of) the table.
+function wipe_table(table_name) {
+  const sql = `TRUNCATE TABLE ${table_name}`;
+
+  connection.query(sql, (error, results, fields) => {
+    if (error) {
+      console.error("Error truncating table: " + error.message);
+      return;
+    }
+    console.log(`Table ${table_name} truncated succesfully!`);
+  });
+}
+
+if (args.length > 2 && args[2] == "wipe") {
+  console.log("Wiping tables...");
+  wipe_table("entries");
+  wipe_table("allev");
+}
+
 async function rest(table) {
   // create application/json parser
-  var jsonParser = bodyParser.json({limit:'10mb'});
+  var jsonParser = bodyParser.json({ limit: "10mb" });
 
   // set table name
   const table_name = "entries";
@@ -106,12 +125,7 @@ async function rest(table) {
       const request = reqBody.request;
       connection.query(
         "INSERT INTO ??.?? (rootUrl, request) VALUES (?,?)",
-        [
-          process.env.DB_DATABASE,
-          "allEv",
-          reqBody.host,
-          request
-        ],
+        [process.env.DB_DATABASE, "allEv", reqBody.host, request],
         (error, results, fields) => {
           if (error) throw error;
           // console.log(results)

--- a/selenium-crawler/local-crawler.js
+++ b/selenium-crawler/local-crawler.js
@@ -117,16 +117,18 @@ async function setup() {
     console.log("clicked alert");
     await new Promise((resolve) => setTimeout(resolve, 2000));
     console.log("alert closed/tour skipped");
-  } catch (e) {
-    console.log("Error: " + e);
-  } finally {
+
     await driver.close(); //close pp window
     await new Promise((resolve) => setTimeout(resolve, 4000));
     await driver.switchTo().window(originalWindow);
-  }
 
-  await new Promise((resolve) => setTimeout(resolve, 3000));
-  console.log("setup complete");
+    await new Promise((resolve) => setTimeout(resolve, 3000));
+    console.log("setup complete");
+  } catch (e) {
+    console.log("Error: " + e);
+    console.log("Error occurred during setup. Restarting driver...");
+    await setup();
+  }
 }
 
 async function visit_site(sites, site_id) {

--- a/selenium-crawler/local-crawler.js
+++ b/selenium-crawler/local-crawler.js
@@ -8,7 +8,7 @@ var total_begin = Date.now(); //start logging time
 var err_obj = new Object();
 // Loads sites to crawl
 const sites = [];
-fs.createReadStream("./test-list.csv")
+fs.createReadStream("./test-list2.csv")
   //fs.createReadStream("../test_crawl_lists/us-ca_test_list.csv")
   //fs.createReadStream("sites.csv")
   //fs.createReadStream("val_set_sites1.csv")


### PR DESCRIPTION
Add fixes to how the crawler handles errors during the setup and the crawl.

Another thing worth testing is the new functionality I added to the rest-api. Running `npm start wipe` will truncate the SQL tables. Helpful if you want to re-do a crawl.

@JoeChampeau For testing the error handling, try running a site that crashes Firefox Nightly multiple times in a row. In my case, looperman.com was helpful. Maybe you can find some others?